### PR TITLE
DI improvements

### DIFF
--- a/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
+++ b/spikeinterface/preprocessing/deepinterpolation/deepinterpolation.py
@@ -1,15 +1,19 @@
 import numpy as np
 import os
 
-from spikeinterface.core.baserecording import BaseRecording
+from ...core import BaseRecording
+from ...core.core_tools import define_function_from_class
 from ..basepreprocessor import BasePreprocessor, BasePreprocessorSegment
 from ..zero_channelpad import ZeroChannelPaddedRecording
 from spikeinterface.core import get_random_data_chunks
 
-try:
-    from tensorflow.keras.models import load_model
-    from tensorflow.keras.utils import Sequence
+
+def import_tf(use_gpu=True):
     import tensorflow as tf
+    
+    if not use_gpu:
+        os.environ['CUDA_VISIBLE_DEVICES'] = '-1'
+    
     tf.compat.v1.disable_eager_execution()
     gpus = tf.config.list_physical_devices('GPU')
     if gpus:
@@ -17,22 +21,27 @@ try:
             # Currently, memory growth needs to be the same across GPUs
             for gpu in gpus:
                 tf.config.experimental.set_memory_growth(gpu, True)
-            logical_gpus = tf.config.list_logical_devices('GPU')
-            print(len(gpus), "Physical GPUs,", len(logical_gpus), "Logical GPUs")
         except RuntimeError as e:
             # Memory growth must be set before GPUs have been initialized
-            print(e)
-    HAVE_TF = True
-except ImportError:
-    HAVE_TF = False
-    
+            print(e)        
+    return tf
+
+def has_tf(use_gpu=True):
+    try:
+        import_tf(use_gpu)
+        return True
+    except ImportError:
+        return False
+
+
 class DeepInterpolatedRecording(BasePreprocessor):
     name = 'deepinterpolate'
-    def __init__(self, recording: BaseRecording, path_to_model: str, 
-                 pre_frames: int, post_frames: int, pre_post_omission: int, 
-                 n_frames_normalize=20000, batch_size=128, use_gpu:bool=False):
+
+    def __init__(self, recording: BaseRecording, model_path: str,
+                 pre_frames: int=30, post_frames: int=30, pre_post_omission: int=1,
+                 batch_size=128, use_gpu: bool = True, **random_chunk_kwargs):
         """Applies DeepInterpolation, a neural network based denoising method, to the recording.
-        
+
         Notes
         -----
         * Currently this only works on Neuropixels 1.0-like recordings with 384 channels.
@@ -41,139 +50,161 @@ class DeepInterpolatedRecording(BasePreprocessor):
         * The specified model must have the same input dimensions as the model from original paper.
         * Will use GPU if available.
         * Inference (application of model) is done lazily, i.e. only when `get_traces` is called.
-        
+
         For more information, see:
         Lecoq et al. (2021) Removing independent noise in systems neuroscience data using DeepInterpolation.
         Nature Methods. 18: 1401-1408. doi: 10.1038/s41592-021-01285-2.
-        
+
         Parts of this code is adapted from https://github.com/AllenInstitute/deepinterpolation.
 
         Parameters
         ----------
         recording : si.BaseRecording
-        path_to_model : str
-            path to pre-trained model
+        model_path : str
+            Path to pre-trained model
         pre_frames : int
-            number of frames before target frame used for training and inference
+            Number of frames before target frame used for training and inference
         post_frames : int
-            number of frames after target frame used for training and inference
+            Number of frames after target frame used for training and inference
         pre_post_omission : int
-            number of frames around the target frame to omit
+            Number of frames around the target frame to omit
         n_frames_normalize : int, optional
-            number of frames to estimate mean and std for normalization, by default 20000
+            Number of frames to estimate mean and std for normalization, by default 20000
         batch_size : int, optional
-            number of frames per batch to infer (adjust based on hardware); by default 128
+            Number of frames per batch to infer (adjust based on hardware); by default 128
+        random_chunk_kwargs: keyword arguments for get_random_data_chunks
         """
-        
-        assert HAVE_TF, "To use DeepInterpolation, you first need to install `tensorflow`."
-        assert recording.get_num_channels() <= 384, ("DeepInterpolation only works on Neuropixels 1.0-like recordings with 384 channels. "
-                                                     "This recording has too many channels.")
-        assert recording.get_num_channels() == 384, ("DeepInterpolation only works on Neuropixels 1.0-like recordings with 384 channels. "
-                                                     "This recording has too few channels. "
-                                                     "Try matching the channel count with `ZeroChannelPaddedRecording`.")
 
-        if use_gpu is False:
-            os.environ['CUDA_VISIBLE_DEVICES']='-1'
-        
+        assert has_tf(use_gpu), "To use DeepInterpolation, you first need to install `tensorflow`."
+        assert recording.get_num_channels() <= 384, ("DeepInterpolation only works on Neuropixels 1.0-like "
+                                                     "recordings with 384 channels. This recording has too many "
+                                                     "channels.")
+        assert recording.get_num_channels() == 384, ("DeepInterpolation only works on Neuropixels 1.0-like "
+                                                     "recordings with 384 channels. "
+                                                     "This recording has too few channels. Try matching the channel "
+                                                     "count with `ZeroChannelPaddedRecording`.")
+        self.tf = import_tf(use_gpu)
+
         BasePreprocessor.__init__(self, recording)
-        
-        # load model
-        self.model = load_model(filepath=path_to_model)
-        
-        # check input shape for the last dimension
-        config = self.model.get_config()
-        input_shape = config["layers"][0]["config"]["batch_input_shape"]
-        assert input_shape[-1]==pre_frames+post_frames, "The sum of `pre_frames` and `post_frames` must match the last dimension of the model."
-        
-        # estimate mean and std
-        if n_frames_normalize > recording.get_num_frames():
-            print('Recording has too few frames; using all frames to estimate mean and std.')
-            n_frames_normalize = recording.get_num_frames()
-        
-        local_data = get_random_data_chunks(recording, chunk_size=n_frames_normalize, num_chunks_per_segment=1, seed=0)
-        if isinstance(recording, ZeroChannelPaddedRecording):            
+
+        local_data = get_random_data_chunks(
+            recording, **random_chunk_kwargs)
+        if isinstance(recording, ZeroChannelPaddedRecording):
             local_data = local_data[:, recording.channel_mapping]
 
         local_mean = np.mean(local_data.flatten())
         local_std = np.std(local_data.flatten())
-        
+
         # add segment
         for segment in recording._recording_segments:
-            recording_segment = DeepInterpolatedRecordingSegment(segment, self.model, pre_frames, post_frames, pre_post_omission,
-                                                                 local_mean, local_std, batch_size)
+            recording_segment = DeepInterpolatedRecordingSegment(segment, model_path,
+                                                                 pre_frames, post_frames, pre_post_omission,
+                                                                 local_mean, local_std, batch_size, use_gpu)
             self.add_recording_segment(recording_segment)
-        
-        self._kwargs = dict(recording=recording.to_dict(), path_to_model=path_to_model, 
-                            pre_frames=pre_frames, post_frames=post_frames, pre_post_omission=pre_post_omission, 
-                            n_frames_normalize=n_frames_normalize, batch_size=batch_size)
-        
+
+        self._kwargs = dict(recording=recording.to_dict(), model_path=model_path,
+                            pre_frames=pre_frames, post_frames=post_frames, pre_post_omission=pre_post_omission,
+                            batch_size=batch_size, **random_chunk_kwargs)
+        self.extra_requirements.extend(['tensorflow'])
+
+
+
 class DeepInterpolatedRecordingSegment(BasePreprocessorSegment):
-    
-    def __init__(self, recording_segment, model, 
-                 pre_frames, post_frames, pre_post_omission, 
-                 local_mean, local_std, batch_size):
-        
+
+    def __init__(self, recording_segment, model_path,
+                 pre_frames, post_frames, pre_post_omission,
+                 local_mean, local_std, batch_size, use_gpu):
+
+        tf = import_tf(use_gpu)
         BasePreprocessorSegment.__init__(self, recording_segment)
-        
-        self.model = model
+
+        self.model = None
+        self.model_path = model_path
         self.pre_frames = pre_frames
         self.post_frames = post_frames
         self.pre_post_omission = pre_post_omission
         self.local_mean = local_mean
         self.local_std = local_std
         self.batch_size = batch_size
+        self.use_gpu = use_gpu
         
-    def get_traces(self, start_frame, end_frame, channel_indices):        
-        
+        # creating class dynamically to use the imported TF with GPU enabled/disabled based on the use_gpu flag
+        self.DeepInterpolationInputGenerator = \
+            type("DeepInterpolationInputGenerator", (tf.keras.utils.Sequence, ), 
+                 {
+                    # constructor
+                    "__init__": di_input_gen_constructor,
+                    "__len__": di_input_gen__len__,
+                    "__getitem__": di_input_gen__getitem__,
+                    # member functions
+                    "reshape_label_forward": di_input_gen_reshape_label_forward,
+                    "reshape_input_forward": di_input_gen_reshape_input_forward
+                })
+    
+    def get_traces(self, start_frame, end_frame, channel_indices):
+        if self.model is None:
+            # first time retrieving traces check that dimensions are ok
+            tf = import_tf(self.use_gpu)
+            tf.keras.backend.clear_session()
+            self.model = tf.keras.models.load_model(
+                filepath=self.model_path)
+            # check input shape for the last dimension
+            config = self.model.get_config()
+            input_shape = config["layers"][0]["config"]["batch_input_shape"]
+            assert input_shape[-1] == self.pre_frames + \
+                self.post_frames, ("The sum of `pre_frames` and `post_frames` must match "
+                                   "the last dimension of the model.")
+
         n_frames = self.parent_recording_segment.get_num_samples()
 
-        if start_frame==None:
+        if start_frame == None:
             start_frame = 0
-        
-        if end_frame==None:
-            end_frame=n_frames
+
+        if end_frame == None:
+            end_frame = n_frames
 
         # for frames that lack full training data (i.e. pre and post frames including omissinos),
         # just return uninterpolated
-        if start_frame<self.pre_frames+self.pre_post_omission:
+        if start_frame < self.pre_frames+self.pre_post_omission:
             true_start_frame = self.pre_frames+self.pre_post_omission
             array_to_append_front = self.parent_recording_segment.get_traces(start_frame=0,
                                                                              end_frame=true_start_frame,
                                                                              channel_indices=channel_indices)
         else:
             true_start_frame = start_frame
-            
-        if end_frame>n_frames-self.post_frames-self.pre_post_omission:
+
+        if end_frame > n_frames-self.post_frames-self.pre_post_omission:
             true_end_frame = n_frames-self.post_frames-self.pre_post_omission
             array_to_append_back = self.parent_recording_segment.get_traces(start_frame=true_end_frame,
                                                                             end_frame=n_frames,
                                                                             channel_indices=channel_indices)
         else:
             true_end_frame = end_frame
-        
-        # instantiate an input generator that can be passed directly to model.predict
-        input_generator = DeepInterpolationInputGenerator(recording=self.parent_recording_segment, 
-                                                          start_frame=true_start_frame,
-                                                          end_frame=true_end_frame,
-                                                          pre_frames=self.pre_frames,
-                                                          post_frames=self.post_frames, 
-                                                          pre_post_omission=self.pre_post_omission, 
-                                                          local_mean=self.local_mean,
-                                                          local_std=self.local_std,
-                                                          batch_size=self.batch_size)
 
+        # instantiate an input generator that can be passed directly to model.predict
+        input_generator = self.DeepInterpolationInputGenerator(recording=self.parent_recording_segment,
+                                                               start_frame=true_start_frame,
+                                                               end_frame=true_end_frame,
+                                                               pre_frames=self.pre_frames,
+                                                               post_frames=self.post_frames,
+                                                               pre_post_omission=self.pre_post_omission,
+                                                               local_mean=self.local_mean,
+                                                               local_std=self.local_std,
+                                                               batch_size=self.batch_size)
         di_output = self.model.predict(input_generator, verbose=2)
-        
+
         out_traces = self.reshape_backward(di_output)
-        
+
         if true_start_frame != start_frame:
-            out_traces = np.concatenate((array_to_append_front, out_traces),axis=0)
+            out_traces = np.concatenate(
+                (array_to_append_front, out_traces), axis=0)
 
         if true_end_frame != end_frame:
-            out_traces = np.concatenate((out_traces, array_to_append_back),axis=0)
+            out_traces = np.concatenate(
+                (out_traces, array_to_append_back), axis=0)
 
         return out_traces[:, channel_indices]
-    
+
     def reshape_backward(self, di_frames):
         """reshapes the prediction from model back to frames
 
@@ -192,150 +223,158 @@ class DeepInterpolatedRecordingSegment(BasePreprocessorSegment):
         n_frames = di_frames.shape[0]
         even = np.arange(0, nb_probes, 2)
         odd = even + 1
-        reshaped_frames = np.zeros((n_frames,384))
+        reshaped_frames = np.zeros((n_frames, 384))
         for frame in range(n_frames):
-            reshaped_frames[frame,0::2] = di_frames[frame,even,0,0]
-            reshaped_frames[frame,1::2] = di_frames[frame,odd,1,0]
+            reshaped_frames[frame, 0::2] = di_frames[frame, even, 0, 0]
+            reshaped_frames[frame, 1::2] = di_frames[frame, odd, 1, 0]
         reshaped_frames = reshaped_frames*self.local_std+self.local_mean
         return reshaped_frames
 
+
 # function for API
-def deepinterpolate(*args, **kwargs):
-    return DeepInterpolatedRecording(*args, **kwargs)
+deepinterpolate = define_function_from_class(source_class=DeepInterpolatedRecording, name="deepinterpolate")
 
-deepinterpolate.__doc__ = DeepInterpolatedRecording.__doc__
+# if HAVE_TF:
+#     tf = import_tf()
+#     class DeepInterpolationInputGenerator(tf.keras.utils.Sequence):
+#         """A data generator class for DeepInterpolation. Useful for both training (fine-tuning) and inference 
+#         (e.g. can set batch size).
+#         Note: this doesn't handle frames that lack complete training data (e.g. frames before pre_frames).
+#         """
 
-class DeepInterpolationInputGenerator(Sequence):
-    """A data generator class for DeepInterpolation. Useful for both training (fine-tuning) and inference (e.g. can set batch size).
-    Note: this doesn't handle frames that lack complete training data (e.g. frames before pre_frames).
+def di_input_gen_constructor(self, recording, start_frame, end_frame, batch_size,
+                pre_frames, post_frames, pre_post_omission,
+                local_mean, local_std):
+    self.recording = recording
+    self.start_frame = start_frame
+    self.end_frame = end_frame
+
+    self.batch_size = batch_size
+    self.last_batch_size = (end_frame-start_frame) - \
+        (self.__len__()-1)*batch_size
+
+    self.pre_frames = pre_frames
+    self.post_frames = post_frames
+    self.pre_post_omission = pre_post_omission
+
+    self.local_mean = local_mean
+    self.local_std = local_std
+
+def di_input_gen__len__(self):
+    return -((self.end_frame-self.start_frame) // -self.batch_size)
+
+def di_input_gen__getitem__(self, idx):
+    n_batches = self.__len__()
+    if idx < n_batches-1:
+        traces = self.recording.get_traces(start_frame=self.start_frame+self.batch_size*idx-self.pre_frames-self.pre_post_omission,
+                                        end_frame=self.start_frame+self.batch_size *
+                                        (idx+1)+self.post_frames +
+                                        self.pre_post_omission,
+                                        channel_indices=slice(None))
+        batch_size = self.batch_size
+    else:
+        traces = self.recording.get_traces(start_frame=self.end_frame-self.last_batch_size-self.pre_frames-self.pre_post_omission,
+                                        end_frame=self.end_frame+self.post_frames+self.pre_post_omission,
+                                        channel_indices=slice(None))
+        batch_size = self.last_batch_size
+
+    shape = (traces.shape[0], int(384 / 2), 2)
+    traces = np.reshape(traces, newshape=shape)
+
+    di_input = np.zeros(
+        (batch_size, 384, 2, self.pre_frames+self.post_frames))
+    di_label = np.zeros((batch_size, 384, 2, 1))
+    for index_frame in range(self.pre_frames+self.pre_post_omission,
+                            batch_size+self.pre_frames+self.pre_post_omission):
+        di_input[index_frame-self.pre_frames -
+                self.pre_post_omission] = self.reshape_input_forward(index_frame, traces)
+        di_label[index_frame-self.pre_frames -
+                self.pre_post_omission] = self.reshape_label_forward(traces[index_frame])
+    return (di_input, di_label)
+
+def di_input_gen_reshape_input_forward(self, index_frame, raw_data):
+    """Reshapes the frames surrounding the target frame to the form expected by model;
+    also subtracts mean and divides by std.
+
+    Parameters
+    ----------
+    index_frame : int
+        index of the frame to be predicted
+    raw_data : ndarray; (frames, 192, 2)
+        a chunk of data used to generate the input
+
+    Returns
+    -------
+    input_full : ndarray; (1, 384, 2, pre_frames+post_frames)
+        input to trained network to predict the center frame
     """
-    def __init__(self, recording, start_frame, end_frame, batch_size,
-                 pre_frames, post_frames, pre_post_omission, 
-                 local_mean, local_std):
-        self.recording = recording
-        self.start_frame = start_frame
-        self.end_frame = end_frame
-        
-        self.batch_size = batch_size
-        self.last_batch_size = (end_frame-start_frame) - (self.__len__()-1)*batch_size
-        
-        self.pre_frames = pre_frames
-        self.post_frames = post_frames
-        self.pre_post_omission = pre_post_omission
-        
-        self.local_mean = local_mean
-        self.local_std = local_std
-        
-    def __len__(self):
-        return -((self.end_frame-self.start_frame) // -self.batch_size)
+    # currently only works for recordings with 384 channels
+    nb_probes = 384
 
-    def __getitem__(self, idx):
-        n_batches = self.__len__()
-        if idx < n_batches-1:
-            traces = self.recording.get_traces(start_frame=self.start_frame+self.batch_size*idx-self.pre_frames-self.pre_post_omission,
-                                               end_frame=self.start_frame+self.batch_size*(idx+1)+self.post_frames+self.pre_post_omission,
-                                               channel_indices=slice(None))
-            batch_size = self.batch_size
-        else:
-            traces = self.recording.get_traces(start_frame=self.end_frame-self.last_batch_size-self.pre_frames-self.pre_post_omission,
-                                               end_frame=self.end_frame+self.post_frames+self.pre_post_omission,
-                                               channel_indices=slice(None))
-            batch_size = self.last_batch_size
-        
-        shape = (traces.shape[0], int(384 / 2), 2)
-        traces = np.reshape(traces, newshape=shape)
-        
-        di_input = np.zeros((batch_size, 384, 2, self.pre_frames+self.post_frames))
-        di_label = np.zeros((batch_size, 384, 2, 1))
-        for index_frame in range(self.pre_frames+self.pre_post_omission,
-                                 batch_size+self.pre_frames+self.pre_post_omission):
-            di_input[index_frame-self.pre_frames-self.pre_post_omission] = self.reshape_input_forward(index_frame, traces)
-            di_label[index_frame-self.pre_frames-self.pre_post_omission] = self.reshape_label_forward(traces[index_frame])
-        return (di_input, di_label)
-    
-    def reshape_input_forward(self, index_frame, raw_data):
-        """Reshapes the frames surrounding the target frame to the form expected by model;
-        also subtracts mean and divides by std.
+    # We reorganize to follow true geometry of probe for convolution
+    input_full = np.zeros(
+        [1, nb_probes, 2,
+        self.pre_frames + self.post_frames], dtype="float32"
+    )
 
-        Parameters
-        ----------
-        index_frame : int
-            index of the frame to be predicted
-        raw_data : ndarray; (frames, 192, 2)
-            a chunk of data used to generate the input
+    input_index = np.arange(
+        index_frame - self.pre_frames - self.pre_post_omission,
+        index_frame + self.post_frames + self.pre_post_omission + 1,
+    )
+    input_index = input_index[input_index != index_frame]
 
-        Returns
-        -------
-        input_full : ndarray; (1, 384, 2, pre_frames+post_frames)
-            input to trained network to predict the center frame
-        """
-        # currently only works for recordings with 384 channels
-        nb_probes = 384
+    for index_padding in np.arange(self.pre_post_omission + 1):
+        input_index = input_index[input_index !=
+                                index_frame - index_padding]
+        input_index = input_index[input_index !=
+                                index_frame + index_padding]
 
-        # We reorganize to follow true geometry of probe for convolution
-        input_full = np.zeros(
-            [1, nb_probes, 2,
-             self.pre_frames + self.post_frames], dtype="float32"
-        )
+    data_img_input = raw_data[input_index, :, :]
 
-        input_index = np.arange(
-            index_frame - self.pre_frames - self.pre_post_omission,
-            index_frame +self.post_frames + self.pre_post_omission + 1,
-        )
-        input_index = input_index[input_index != index_frame]
+    data_img_input = np.swapaxes(data_img_input, 1, 2)
+    data_img_input = np.swapaxes(data_img_input, 0, 2)
 
-        for index_padding in np.arange(self.pre_post_omission + 1):
-            input_index = input_index[input_index !=
-                                      index_frame - index_padding]
-            input_index = input_index[input_index !=
-                                      index_frame + index_padding]
+    even = np.arange(0, nb_probes, 2)
+    odd = even + 1
 
-        data_img_input = raw_data[input_index, :, :]
+    data_img_input = (
+        data_img_input.astype("float32") - self.local_mean
+    ) / self.local_std
 
-        data_img_input = np.swapaxes(data_img_input, 1, 2)
-        data_img_input = np.swapaxes(data_img_input, 0, 2)
+    input_full[0, even, 0, :] = data_img_input[:, 0, :]
+    input_full[0, odd, 1, :] = data_img_input[:, 1, :]
+    return input_full
 
-        even = np.arange(0, nb_probes, 2)
-        odd = even + 1
+def di_input_gen_reshape_label_forward(self, label):
+    """Reshapes the target frame to the form expected by model.
 
-        data_img_input = (
-            data_img_input.astype("float32") - self.local_mean
-        ) / self.local_std
+    Parameters
+    ----------
+    label : ndarray, (1, 192, 2)
 
-        input_full[0, even, 0, :] = data_img_input[:, 0, :]
-        input_full[0, odd, 1, :] = data_img_input[:, 1, :]
-        return input_full
-    
-    def reshape_label_forward(self, label):
-        """Reshapes the target frame to the form expected by model.
+    Returns
+    -------
+    reshaped_label : ndarray, (1, 384, 2, 1)
+        target frame after reshaping
+    """
+    # currently only works for recordings with 384 channels
+    nb_probes = 384
 
-        Parameters
-        ----------
-        label : ndarray, (1, 192, 2)
+    input_full = np.zeros(
+        [1, nb_probes, 2, 1], dtype="float32"
+    )
 
-        Returns
-        -------
-        reshaped_label : ndarray, (1, 384, 2, 1)
-            target frame after reshaping
-        """
-        # currently only works for recordings with 384 channels
-        nb_probes = 384
-        
-        input_full = np.zeros(
-            [1, nb_probes, 2, 1], dtype="float32"
-        )
+    data_img_input = np.expand_dims(label, axis=0)
+    data_img_input = np.swapaxes(data_img_input, 1, 2)
+    data_img_input = np.swapaxes(data_img_input, 0, 2)
 
-        data_img_input = np.expand_dims(label,axis=0)
-        data_img_input = np.swapaxes(data_img_input, 1, 2)
-        data_img_input = np.swapaxes(data_img_input, 0, 2)
+    even = np.arange(0, nb_probes, 2)
+    odd = even + 1
 
-        even = np.arange(0, nb_probes, 2)
-        odd = even + 1
+    data_img_input = (
+        data_img_input.astype("float32") - self.local_mean
+    ) / self.local_std
 
-        data_img_input = (
-            data_img_input.astype("float32") - self.local_mean
-        ) / self.local_std
-
-        input_full[0, even, 0, :] = data_img_input[:, 0, :]
-        input_full[0, odd, 1, :] = data_img_input[:, 1, :]
-        return input_full
+    input_full[0, even, 0, :] = data_img_input[:, 0, :]
+    input_full[0, odd, 1, :] = data_img_input[:, 1, :]
+    return input_full

--- a/spikeinterface/preprocessing/preprocessinglist.py
+++ b/spikeinterface/preprocessing/preprocessinglist.py
@@ -19,7 +19,7 @@ from .remove_bad_channels import RemoveBadChannelsRecording, remove_bad_channels
 from .phase_shift import PhaseShiftRecording, phase_shift
 from .zero_channelpad import ZeroChannelPaddedRecording, zero_channelpad
 # not importing deepinterpolation by default
-# from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate
+from .deepinterpolation import DeepInterpolatedRecording, deepinterpolate
 
 preprocessers_full_list = [
     # filter stuff


### PR DESCRIPTION
Hi @khl02007 

I worked a bit on the DI PR but wanted to run some of the changes by you.

In this PR there are two major changes: 

1. the loading of TF is on the fly and it can be with or without GPU. Note that the `CUDA_VISIBLE_DEVICES` needs to be set before importing tf, so I changed the logic of testing if tf is available. 

2. moved model loading to `get_traces` of segment: the reason why the multiprocessing didn't work is that the model cannot be loaded in the parent and child processes, because keras sets some environment variables etc.. so now the model loading happens the first time the `get_traces` is called. Now, parallel writing works! BUT, only for CPU.. here is some benchmarks:

 - 1 job - CPU - write 1sec traces in 100ms chunks

![image](https://user-images.githubusercontent.com/17097257/177046267-258e10dc-18ec-4cb0-9600-c589fa52ecab.png)

 - 4 job - CPU - write 1sec traces in 100ms chunks
![image](https://user-images.githubusercontent.com/17097257/177046309-a5bff43b-a035-42ea-a830-29e2417c0a2f.png)

 - 1 job - GPU - write 1sec traces in 100ms chunks
![image](https://user-images.githubusercontent.com/17097257/177046324-ca1d78bb-bb96-4502-86c8-924ef9daa432.png)


So, GPU is way faster, but using >40 CPUs might scale well! Ideally, we'll be able to solve also muliple jobs on GPUs

**NOTE**: I had to define the `DeepInterpolationInputGenerator` as a dynamic class in the segment in order to use the correct GPU/CPU device. Alternatively, we can always load tensorflow "full" and use `tf.device` context to dynamically run on devices...

Let me know what you think!